### PR TITLE
Fixed wait when machine was suspended.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2022-05-10
+### Fixed
+- Wait for the next event was wrong when the machine was suspended.
+
 ## [1.2.0] - 2022-05-07
 ### Added
 - Allowed date interval lines without a starting dash

--- a/src/Library/OneTimeTask.cs
+++ b/src/Library/OneTimeTask.cs
@@ -19,7 +19,7 @@ public record OneTimeTask(string ActionId, Func<CancellationToken, Task> Action,
         TimeSpan waitingTime = randomizedTime - now;
         Console.WriteLine($"Waiting time: {waitingTime}");
         
-        await Task.Delay(waitingTime, cancellationToken);
+        await TaskEx.RealTimeDelay(waitingTime, TimeSpan.FromSeconds(1), cancellationToken);
         Console.WriteLine($"Executing {ActionId}");
         await Action(cancellationToken);
     }

--- a/src/Library/TaskEx.cs
+++ b/src/Library/TaskEx.cs
@@ -1,0 +1,25 @@
+namespace Scheduler;
+
+public static class TaskEx
+{
+    public static Task RealTimeDelay(TimeSpan delay) =>
+        RealTimeDelay(delay, CancellationToken.None);
+
+
+    public static Task RealTimeDelay(TimeSpan delay, TimeSpan precision) =>
+        RealTimeDelay(delay, precision, CancellationToken.None);
+
+    public static Task RealTimeDelay(TimeSpan delay, CancellationToken token) =>
+        RealTimeDelay(delay, TimeSpan.FromMilliseconds(500), token);
+
+    public static async Task RealTimeDelay(TimeSpan delay, TimeSpan precision, CancellationToken token)
+    {
+        DateTime start = DateTime.UtcNow;
+        DateTime end = start + delay;
+
+        while (DateTime.UtcNow < end)
+        {
+            await Task.Delay(precision, token);
+        }
+    }
+}


### PR DESCRIPTION
When running, sched didn't wait for the correct amount of time when the machine was suspended in between. The current fix will NOT wake the machine up, but at least it will execute all pending tasks immediately when the machine wakes up. If the machine is awake when the event comes, it will always execute on time.